### PR TITLE
Updated policies

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,5 @@ RESEND_EMAIL='Progress Team <noreply@subdomainhere>'
 
 # GitHub App Configuration (for Policy Management)
 GITHUB_APP_ID=123456
-GITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nYourPrivateKeyHere\n-----END RSA PRIVATE KEY-----
 GITHUB_INSTALLATION_ID=12345678
 GITHUB_ORGANIZATION=your-org-name

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -249,7 +249,9 @@ const createUser = async (req, res) => {
         userId: result.id, 
         email: result.email, 
         role: derivePrimaryRole(result.roles),
-        roles: Array.isArray(result.roles) ? result.roles : []
+        roles: Array.isArray(result.roles) ? result.roles : [],
+        firstName: result.firstName,
+        lastName: result.lastName
       },
       process.env.JWT_SECRET || 'your-secret-key',
       { expiresIn: '24h' }
@@ -419,7 +421,9 @@ const loginUser = async (req, res) => {
         userId: user.id, 
         email: user.email, 
         role: derivePrimaryRole(user.roles),
-        roles: Array.isArray(user.roles) ? user.roles : []
+        roles: Array.isArray(user.roles) ? user.roles : [],
+        firstName: user.firstName,
+        lastName: user.lastName
       },
       process.env.JWT_SECRET || 'your-secret-key',
       { expiresIn: '24h' }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -50,8 +50,9 @@ Curious? Join us at ${websiteUrl}
   const isMobilePlatform = Platform.OS === 'ios' || Platform.OS === 'android';
   
   // Define unauthenticated routes that should show aurora background
-  const unauthenticatedRoutes = ['/', '/about', '/our-approach', '/join', '/login', '/register', '/nda', '/settings', '/eula', '/privacy-policy', '/policy'];
-  const shouldShowAurora = unauthenticatedRoutes.includes(pathname) && !isMobilePlatform;
+  const unauthenticatedRoutes = ['/', '/about', '/our-approach', '/join', '/login', '/register', '/nda', '/settings', '/eula', '/privacy-policy'];
+  const isEditorRoute = /^\/policy\/[^/]+\/edit(\?.*)?$/.test(pathname || '');
+  const shouldShowAurora = (unauthenticatedRoutes.includes(pathname) || pathname.startsWith('/policy')) && !isMobilePlatform && !isEditorRoute;
   
   return (
     <View style={[{ flex: 1 }, commonStyles.appContainer]}>
@@ -106,7 +107,7 @@ Curious? Join us at ${websiteUrl}
         </View>
       )}
       
-      <Header />
+      {!isEditorRoute && <Header />}
       <View style={{ flex: 1 }}>
         <Stack screenOptions={{ headerShown: false }} />
       </View>

--- a/frontend/app/policy.tsx
+++ b/frontend/app/policy.tsx
@@ -1,133 +1,55 @@
 import React, { useState, useEffect } from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, Alert, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, FlatList } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import Markdown from 'react-native-markdown-display';
 import SEOHead from '../components/SEOHead';
-import { getCommonStyles, getGradients, getColors } from '../util/commonStyles';
+import { getCommonStyles, getColors } from '../util/commonStyles';
 import { useTheme } from '../util/theme-context';
 import { useResponsive } from '../util/useResponsive';
-import { useAuth } from '../util/auth-context';
 import { api } from '../util/api';
 
 // Define interfaces for our data types
 interface Repository {
   id: string;
   name: string;
-}
-
-interface Branch {
-  name: string;
-}
-
-interface PullRequest {
-  id: string;
-  title: string;
-  state: string;
+  displayName?: string;
 }
 
 export default function Policy() {
   const router = useRouter();
   const { isDark } = useTheme();
   const { isMobile, width } = useResponsive();
-  const { user, isAuthenticated } = useAuth();
   const commonStyles = getCommonStyles(isDark, isMobile, width);
-  const gradients = getGradients(isDark);
   const colors = getColors(isDark);
   const styles = getStyles(colors, isMobile, width);
 
   const [repos, setRepos] = useState<Repository[]>([]);
-  const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null);
-  const [content, setContent] = useState('');
-  const [branches, setBranches] = useState<Branch[]>([]);
-  const [prs, setPrs] = useState<PullRequest[]>([]);
-  const [editing, setEditing] = useState(false);
-  const [editContent, setEditContent] = useState('');
   const [loading, setLoading] = useState(false);
-  const [contentLoading, setContentLoading] = useState(false);
-  const [preview, setPreview] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  const isWriter =
-    (user?.roles && (user.roles.includes('WRITER') || user.roles.includes('ADMIN')));
-
+  // Load repos on mount
   useEffect(() => {
     fetchRepos();
   }, []);
 
-  useEffect(() => {
-    if (selectedRepo) {
-      fetchContent();
-      if (isWriter) {
-        fetchBranches();
-        fetchPRs();
-      }
-    }
-  }, [selectedRepo]);
-
   const fetchRepos = async () => {
     try {
+      setLoading(true);
       const data = await api.getPolicyRepos();
-      setRepos(data);
-      if (data.length > 0) {
-        setSelectedRepo(data[0]);
-      }
+      // Fetch titles for each repo
+      const reposWithTitles = await Promise.all(data.map(async (repo) => {
+        try {
+          const contentData = await api.getPolicyContent(repo.name, 'policy.md');
+          const lines = contentData.content.split('\n');
+          const firstHeading = lines.find(line => line.startsWith('# '));
+          const title = firstHeading ? firstHeading.replace(/^#+\s*/, '') : repo.name;
+          return { ...repo, displayName: title };
+        } catch {
+          return { ...repo, displayName: repo.name };
+        }
+      }));
+      setRepos(reposWithTitles);
     } catch (error) {
       console.error('Error fetching repos:', error);
-    }
-  };
-
-  const fetchContent = async () => {
-    try {
-      if (!selectedRepo) return;
-      setError(null);
-      setContentLoading(true);
-      const data = await api.getPolicyContent(selectedRepo.name, 'policy.md');
-      setContent(data.content);
-      setEditContent(data.content);
-    } catch (error) {
-      console.error('Error fetching content:', error);
-      setError('Failed to load policy content');
-      setContent('No policy content found.');
-    } finally {
-      setContentLoading(false);
-    }
-  };
-
-  const fetchBranches = async () => {
-    try {
-      if (!selectedRepo) return;
-      
-      const data = await api.getPolicyBranches(selectedRepo.name);
-      setBranches(data);
-    } catch (error) {
-      console.error('Error fetching branches:', error);
-    }
-  };
-
-  const fetchPRs = async () => {
-    try {
-      if (!selectedRepo) return;
-      
-      const data = await api.getPolicyPRs(selectedRepo.name);
-      setPrs(data);
-    } catch (error) {
-      console.error('Error fetching PRs:', error);
-    }
-  };
-
-  const handleEdit = async () => {
-    if (!selectedRepo) return;
-    
-    setLoading(true);
-    try {
-      await api.editPolicy(selectedRepo.name, 'policy.md', editContent, 'Updated policy');
-      Alert.alert('Success', 'Policy updated and PR created!');
-      setEditing(false);
-      fetchContent(); // Refresh content
-    } catch (error) {
-      console.error('Error editing policy:', error);
-      Alert.alert('Error', 'Failed to update policy');
     } finally {
       setLoading(false);
     }
@@ -143,145 +65,33 @@ export default function Policy() {
             <Text style={[commonStyles.text, styles.heroSubtext]}>Our guiding principles and policies</Text>
           </View>
 
-          {/* Role/Access Banner */}
-          <View style={[styles.section, styles.banner]}>
-            {isAuthenticated ? (
-              <View style={styles.bannerRow}>
-                <View style={[styles.badge, isWriter ? styles.badgeEditor : styles.badgeMember]}>
-                  <MaterialIcons name={isWriter ? 'edit' : 'person'} size={16} color="#fff" />
-                  <Text style={styles.badgeText}>{isWriter ? 'Editor Access' : 'Member Access'}</Text>
-                </View>
-                <Text style={[commonStyles.text, styles.bannerText]}>
-                  {isWriter ? 'You can edit and propose changes.' : 'You can view policies. Editing requires writer permissions.'}
-                </Text>
+          {/* Repo list */}
+          <View style={styles.section}>
+            <Text style={[commonStyles.text, styles.sectionTitle]}>Select a Policy</Text>
+            {loading ? (
+              <View style={styles.loadingBox}>
+                <ActivityIndicator color={colors.accent} />
+                <Text style={[commonStyles.text, styles.loadingText]}>Loading policies…</Text>
               </View>
             ) : (
-              <View style={styles.bannerRow}>
-                <Text style={[commonStyles.text, styles.bannerText]}>Sign in to contribute or join our community.</Text>
-                <View style={styles.ctaRow}>
-                  <TouchableOpacity style={[styles.smallButton, styles.primaryCta]} onPress={() => router.push('/login')}>
-                    <Text style={styles.smallButtonText}>Sign In</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity style={[styles.smallButton, styles.secondaryCta]} onPress={() => router.push('/join')}>
-                    <Text style={styles.smallButtonText}>Join</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-          </View>
-
-          {/* Repo Selector */}
-          <View style={styles.section}>
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.repoChips}>
-              {repos.map((repo) => (
-                <TouchableOpacity
-                  key={repo.id}
-                  style={[styles.repoChip, selectedRepo?.id === repo.id && styles.selectedRepo]}
-                  onPress={() => setSelectedRepo(repo)}
-                >
-                  <MaterialIcons name="policy" size={16} color={selectedRepo?.id === repo.id ? '#fff' : colors.text} />
-                  <Text style={[commonStyles.text, styles.repoChipText, selectedRepo?.id === repo.id && styles.repoChipTextSelected]}>{repo.name}</Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
-          </View>
-
-          {/* Policy Content */}
-          {selectedRepo && (
-            <View style={styles.section}>
-              <Text style={[commonStyles.text, styles.sectionTitle]}>Policy Content</Text>
-              {contentLoading ? (
-                <View style={styles.loadingBox}>
-                  <ActivityIndicator color={colors.accent} />
-                  <Text style={[commonStyles.text, styles.loadingText]}>Loading content…</Text>
-                </View>
-              ) : editing ? (
-                <View>
-                  <View style={styles.toggleRow}>
-                    <TouchableOpacity
-                      style={[styles.toggleButton, !preview && styles.toggleButtonInactive]}
-                      onPress={() => setPreview(true)}
-                    >
-                      <Text style={styles.toggleText}>Preview</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={[styles.toggleButton, preview && styles.toggleButtonInactive]}
-                      onPress={() => setPreview(false)}
-                    >
-                      <Text style={styles.toggleText}>Edit</Text>
-                    </TouchableOpacity>
-                  </View>
-
-                  {preview ? (
-                    <View style={styles.previewBox}>
-                      <Markdown style={getMarkdownStyles(colors)}>{editContent}</Markdown>
-                    </View>
-                  ) : (
-                    <TextInput
-                      style={styles.editInput}
-                      multiline
-                      value={editContent}
-                      onChangeText={setEditContent}
-                      placeholder="Enter policy content..."
-                      placeholderTextColor={colors.textSecondary}
-                    />
-                  )}
-                  <View style={styles.buttonRow}>
-                    <TouchableOpacity style={styles.saveButton} onPress={handleEdit} disabled={loading}>
-                      <Text style={styles.buttonText}>{loading ? 'Saving...' : 'Save & Create PR'}</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity style={styles.cancelButton} onPress={() => setEditing(false)}>
-                      <Text style={styles.buttonText}>Cancel</Text>
-                    </TouchableOpacity>
-                  </View>
-                </View>
-              ) : (
-                <>
-                  {error && (
-                    <View style={styles.errorBox}>
-                      <MaterialIcons name="error-outline" size={18} color={colors.error} />
-                      <Text style={[commonStyles.text, styles.errorText]}>{error}</Text>
-                    </View>
-                  )}
-                  <Markdown style={getMarkdownStyles(colors)}>{content}</Markdown>
-                </>
-              )}
-            </View>
-          )}
-
-          {/* Writer Features */}
-          {isWriter && selectedRepo && (
-            <>
-              <View style={styles.section}>
-                {!editing && (
-                  <TouchableOpacity style={styles.editButton} onPress={() => { setPreview(true); setEditing(true); }}>
-                    <Text style={styles.buttonText}>Edit Policy</Text>
+              <FlatList
+                data={repos}
+                keyExtractor={(item) => item.id}
+                numColumns={isMobile ? 1 : 2}
+                renderItem={({item}) => (
+                  <TouchableOpacity
+                    style={styles.repoCard}
+                    onPress={() => router.push(`/policy/${item.name}`)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open ${item.displayName || item.name} policy`}
+                  >
+                    <MaterialIcons name="policy" size={32} color={colors.accent} />
+                    <Text style={[commonStyles.text, styles.repoCardText]}>{item.displayName || item.name}</Text>
                   </TouchableOpacity>
                 )}
-              </View>
-
-              {/* Branches */}
-              <View style={styles.section}>
-                <Text style={[commonStyles.text, styles.sectionTitle]}>Branches</Text>
-                {branches.map((branch) => (
-                  <View key={branch.name} style={styles.listItem}>
-                    <Text style={commonStyles.text}>{branch.name}</Text>
-                  </View>
-                ))}
-              </View>
-
-              {/* PRs */}
-              <View style={styles.section}>
-                <Text style={[commonStyles.text, styles.sectionTitle]}>Pull Requests</Text>
-                {prs.map((pr) => (
-                  <View key={pr.id} style={styles.listItem}>
-                    <Text style={commonStyles.text}>{pr.title}</Text>
-                    <Text style={[commonStyles.text, styles.prState]}>{pr.state}</Text>
-                  </View>
-                ))}
-              </View>
-            </>
-          )}
+              />
+            )}
+          </View>
 
           <View style={{ height: 100 }} />
         </ScrollView>
@@ -301,63 +111,6 @@ const getStyles = (colors: any, isMobile: boolean, width: number) => StyleSheet.
     marginTop: 8,
     opacity: 0.8,
   },
-  banner: {
-    paddingVertical: 12,
-    paddingHorizontal: isMobile ? 16 : 24,
-    backgroundColor: colors.surface,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  bannerRow: {
-    gap: 8,
-  },
-  bannerText: {
-    opacity: 0.9,
-    marginTop: 4,
-  },
-  ctaRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginTop: 12,
-  },
-  smallButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  primaryCta: {
-    backgroundColor: colors.accent,
-    borderColor: colors.accent,
-  },
-  secondaryCta: {
-    backgroundColor: 'transparent',
-  },
-  smallButtonText: {
-    color: '#fff',
-    fontWeight: 'bold',
-  },
-  badge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    alignSelf: 'flex-start',
-    paddingVertical: 4,
-    paddingHorizontal: 10,
-    borderRadius: 999,
-  },
-  badgeText: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-  badgeEditor: {
-    backgroundColor: colors.accent,
-  },
-  badgeMember: {
-    backgroundColor: colors.secondary,
-  },
   section: {
     marginBottom: 40,
     paddingHorizontal: isMobile ? 20 : 40,
@@ -367,74 +120,6 @@ const getStyles = (colors: any, isMobile: boolean, width: number) => StyleSheet.
     fontWeight: 'bold',
     marginBottom: 16,
   },
-  repoChips: {
-    alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 4,
-  },
-  repoChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 999,
-    marginRight: 8,
-    backgroundColor: colors.surface,
-  },
-  selectedRepo: {
-    backgroundColor: colors.accent,
-    borderColor: colors.accent,
-  },
-  repoChipText: {
-    color: colors.text,
-  },
-  repoChipTextSelected: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-  editInput: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 8,
-    padding: 12,
-    minHeight: 200,
-    textAlignVertical: 'top',
-    color: colors.text,
-  },
-  buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginTop: 16,
-  },
-  saveButton: {
-    backgroundColor: colors.accent,
-    padding: 12,
-    borderRadius: 8,
-    flex: 1,
-    marginRight: 8,
-    alignItems: 'center',
-  },
-  cancelButton: {
-    backgroundColor: colors.secondary,
-    padding: 12,
-    borderRadius: 8,
-    flex: 1,
-    marginLeft: 8,
-    alignItems: 'center',
-  },
-  editButton: {
-    backgroundColor: colors.accent,
-    padding: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: '#FFFFFF',
-    fontWeight: 'bold',
-  },
   listItem: {
     padding: 12,
     borderWidth: 1,
@@ -443,10 +128,6 @@ const getStyles = (colors: any, isMobile: boolean, width: number) => StyleSheet.
     marginBottom: 8,
     flexDirection: 'row',
     justifyContent: 'space-between',
-  },
-  prState: {
-    fontSize: 12,
-    opacity: 0.7,
   },
   loadingBox: {
     paddingVertical: 20,
@@ -456,76 +137,23 @@ const getStyles = (colors: any, isMobile: boolean, width: number) => StyleSheet.
   loadingText: {
     opacity: 0.8,
   },
-  toggleRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginBottom: 12,
-  },
-  toggleButton: {
+  repoCard: {
     flex: 1,
-    backgroundColor: colors.accent,
-    paddingVertical: 10,
-    borderRadius: 8,
     alignItems: 'center',
-  },
-  toggleButtonInactive: {
-    backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  toggleText: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-  previewBox: {
+    padding: 24,
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: 8,
-    padding: 12,
-    marginBottom: 12,
-  },
-  errorBox: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    borderWidth: 1,
-    borderColor: colors.error,
+    margin: 12,
     backgroundColor: colors.surface,
-    padding: 10,
-    borderRadius: 8,
-    marginBottom: 12,
   },
-  errorText: {
-    color: colors.error,
-  },
-});
-
-const getMarkdownStyles = (colors: any) => ({
-  body: {
-    color: colors.text,
-  },
-  heading1: {
-    fontSize: 24,
+  repoCardText: {
+    marginTop: 8,
     fontWeight: 'bold',
-    marginBottom: 16,
-    color: colors.text,
+    fontSize: isMobile ? 16 : 18,
   },
-  heading2: {
-    fontSize: 20,
+  buttonText: {
+    color: '#FFFFFF',
     fontWeight: 'bold',
-    marginBottom: 12,
-    color: colors.text,
-  },
-  paragraph: {
-    marginBottom: 12,
-    lineHeight: 20,
-    color: colors.text,
-  },
-  listItem: {
-    marginBottom: 8,
-    color: colors.text,
-  },
-  link: {
-    color: colors.accent,
   },
 });

--- a/frontend/app/policy/[repo].tsx
+++ b/frontend/app/policy/[repo].tsx
@@ -1,0 +1,252 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Linking } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
+import Markdown from 'react-native-markdown-display';
+
+import SEOHead from '../../components/SEOHead';
+import { useTheme } from '../../util/theme-context';
+import { useResponsive } from '../../util/useResponsive';
+import { getCommonStyles, getColors } from '../../util/commonStyles';
+import { useAuth } from '../../util/auth-context';
+import { api } from '../../util/api';
+
+interface Branch { name: string }
+interface PullRequest { id: string; title: string; state: string; html_url: string }
+
+export default function PolicyContent() {
+  const router = useRouter();
+  const { repo } = useLocalSearchParams<{ repo: string }>();
+  const { isDark } = useTheme();
+  const { isMobile, width } = useResponsive();
+  const { user } = useAuth();
+  const commonStyles = getCommonStyles(isDark, isMobile, width);
+  const colors = getColors(isDark);
+  const styles = getStyles(colors, isMobile);
+
+  const [content, setContent] = useState('');
+  const [title, setTitle] = useState(repo || '');
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [prs, setPrs] = useState<PullRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const isWriter = user?.roles?.includes('WRITER') || user?.roles?.includes('ADMIN');
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      if (!repo) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await api.getPolicyContent(String(repo), 'policy.md');
+        if (!mounted) return;
+        setContent(data.content);
+        // Extract the first heading from the content
+        const lines = data.content.split('\n');
+        const firstHeading = lines.find(line => line.startsWith('# '));
+        if (firstHeading) {
+          setTitle(firstHeading.replace(/^#+\s*/, ''));
+        } else {
+          setTitle(repo || '');
+        }
+        if (isWriter) {
+          const [b, p] = await Promise.all([
+            api.getPolicyBranches(String(repo)),
+            api.getPolicyPRs(String(repo))
+          ]);
+          if (!mounted) return;
+          setBranches(b);
+          setPrs(p);
+        }
+      } catch (e) {
+        console.error('Error loading policy content:', e);
+        setError('Failed to load policy content');
+        setContent('');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+    return () => { mounted = false };
+  }, [repo]);
+
+  return (
+    <>
+      <SEOHead pageKey="policy" />
+      <View style={commonStyles.appContainer}>
+        <ScrollView contentContainerStyle={commonStyles.content} showsVerticalScrollIndicator={false}>
+          <View style={styles.heroSection}>
+            <View style={styles.titleContainer}>
+              <Text style={commonStyles.title}>{title}</Text>
+              <Text style={[commonStyles.text, styles.heroSubtext]}>Policy contents</Text>
+            </View>
+            <TouchableOpacity style={styles.backButton} onPress={() => router.push('/policy')}>
+              <MaterialIcons name="arrow-back" size={24} color={colors.text} />
+              <Text style={[commonStyles.text, styles.backText]}>Back to Policies</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.section}>
+            {loading ? (
+              <View style={styles.loadingBox}>
+                <ActivityIndicator color={colors.accent} />
+                <Text style={[commonStyles.text, styles.loadingText]}>Loading…</Text>
+              </View>
+            ) : error ? (
+              <View style={styles.errorBox}>
+                <MaterialIcons name="error-outline" size={18} color={colors.error} />
+                <Text style={[commonStyles.text, styles.errorText]}>{error}</Text>
+              </View>
+            ) : (
+              <Markdown style={getMarkdownStyles(colors)}>{content || 'No policy content found.'}</Markdown>
+            )}
+          </View>
+
+          {isWriter && (
+            <>
+              <View style={styles.section}>
+                <TouchableOpacity
+                  style={styles.editButton}
+                  onPress={() => router.push(`/policy/${repo}/edit`)}
+                >
+                  <Text style={styles.editButtonText}>Open Editor</Text>
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.section}>
+                <Text style={[commonStyles.text, styles.sectionTitle]}>Branches</Text>
+                {branches.map((b) => (
+                  <View key={b.name} style={styles.listItem}>
+                    <Text style={commonStyles.text}>{b.name}</Text>
+                  </View>
+                ))}
+              </View>
+
+              <View style={styles.section}>
+                <Text style={[commonStyles.text, styles.sectionTitle]}>Pull Requests</Text>
+                {prs.map((pr) => (
+                  <View key={pr.id} style={styles.listItem}>
+                    <Text style={commonStyles.text}>{pr.title}</Text>
+                    <View style={{flexDirection: 'row', alignItems: 'center', gap: 8}}>
+                      <Text style={[commonStyles.text, styles.prState]}>{pr.state}</Text>
+                      <TouchableOpacity onPress={() => Linking.openURL(pr.html_url)}>
+                        <Text style={styles.openText}>Open</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            </>
+          )}
+
+          <View style={{ height: 100 }} />
+        </ScrollView>
+      </View>
+    </>
+  );
+}
+
+const getStyles = (colors: any, isMobile: boolean) => StyleSheet.create({
+  heroSection: {
+    marginBottom: 40,
+    alignItems: 'center',
+    position: 'relative',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+  },
+  spacer: {
+    flex: 1,
+  },
+  titleContainer: {
+    alignItems: 'center',
+  },
+  heroSubtext: {
+    fontSize: isMobile ? 16 : 18,
+    fontStyle: 'italic',
+    marginTop: 8,
+    opacity: 0.8,
+  },
+  section: {
+    marginBottom: 40,
+    paddingHorizontal: isMobile ? 20 : 40,
+  },
+  sectionTitle: {
+    fontSize: isMobile ? 18 : 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  listItem: {
+    padding: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    marginBottom: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  prState: {
+    fontSize: 12,
+    opacity: 0.7,
+  },
+  openText: {
+    color: colors.accent,
+    fontWeight: 'bold',
+  },
+  loadingBox: {
+    paddingVertical: 20,
+    alignItems: 'center',
+    gap: 8,
+  },
+  loadingText: {
+    opacity: 0.8,
+  },
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderWidth: 1,
+    borderColor: colors.error,
+    backgroundColor: colors.surface,
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  errorText: {
+    color: colors.error,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    alignSelf: 'flex-start',
+    marginBottom: 12,
+  },
+  backText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  editButton: {
+    backgroundColor: colors.accent,
+    padding: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  editButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});
+
+const getMarkdownStyles = (colors: any) => ({
+  body: { color: colors.text },
+  heading1: { fontSize: 24, fontWeight: 'bold', marginBottom: 16, color: colors.text },
+  heading2: { fontSize: 20, fontWeight: 'bold', marginBottom: 12, color: colors.text },
+  paragraph: { marginBottom: 12, lineHeight: 20, color: colors.text },
+  listItem: { marginBottom: 8, color: colors.text },
+  link: { color: colors.accent },
+});

--- a/frontend/app/policy/[repo]/edit.tsx
+++ b/frontend/app/policy/[repo]/edit.tsx
@@ -1,0 +1,337 @@
+import React, { useEffect, useMemo, useRef, useState, Suspense } from 'react';
+import { Platform, View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, Alert } from 'react-native';
+import Head from 'expo-router/head';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import Markdown from 'react-native-markdown-display';
+
+import { useTheme } from '../../../util/theme-context';
+import { useResponsive } from '../../../util/useResponsive';
+import { getCommonStyles, getColors } from '../../../util/commonStyles';
+import { useAuth } from '../../../util/auth-context';
+import { api } from '../../../util/api';
+
+// Lazy-load the SimpleMDE editor for web
+let WebMDE: any = null;
+const isWeb = Platform.OS === 'web';
+if (isWeb) {
+  // Dynamic import at runtime to avoid bundling issues in native
+  import('react-simplemde-editor').then((mod) => {
+    WebMDE = mod.default;
+  }).catch(() => {
+    WebMDE = null;
+  });
+}
+
+export default function PolicyEditor() {
+  const router = useRouter();
+  const { repo } = useLocalSearchParams<{ repo: string }>();
+  const { isDark } = useTheme();
+  const { isMobile, width } = useResponsive();
+  const { user } = useAuth();
+  const commonStyles = getCommonStyles(isDark, isMobile, width);
+  const colors = getColors(isDark);
+  const styles = getStyles(colors, isMobile);
+  const scrollRef = useRef<any>(null);
+
+  const [content, setContent] = useState('');
+  const [commitMessage, setCommitMessage] = useState('Update policy.md');
+  const [branchName, setBranchName] = useState('policy/update-' + Date.now());
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPreview, setIsPreview] = useState(false);
+
+  const isWriter = user?.roles?.includes('WRITER') || user?.roles?.includes('ADMIN');
+
+  useEffect(() => {
+    // Ensure page opens scrolled to top
+    if (isWeb && typeof window !== 'undefined') {
+      try {
+        window.scrollTo({ top: 0, behavior: 'auto' });
+      } catch {}
+    }
+    // Also reset any ScrollView ref position
+    setTimeout(() => {
+      try {
+        scrollRef.current?.scrollTo?.({ y: 0, animated: false });
+      } catch {}
+    }, 0);
+
+    let mounted = true;
+    async function load() {
+      if (!repo) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await api.getPolicyContent(String(repo), 'policy.md');
+        if (!mounted) return;
+        setContent(data.content || '');
+      } catch (e) {
+        setError('Failed to load policy for editing');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+    return () => { mounted = false };
+  }, [repo]);
+
+  const handleSave = async () => {
+    if (!repo) return;
+    try {
+      setSaving(true);
+      await api.editPolicy(String(repo), 'policy.md', content, commitMessage || 'Update policy.md', branchName || undefined);
+      Alert.alert('Success', 'Policy updated and PR created!');
+      router.replace(`/policy/${repo}`);
+    } catch (e) {
+      Alert.alert('Error', 'Failed to save policy changes');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Guard non-writers
+  if (!isWriter) {
+    return (
+      <View style={[{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }, commonStyles.appContainer]}>
+        <Text style={{ color: colors.text, marginBottom: 12, fontSize: 16 }}>You do not have access to the policy editor.</Text>
+        <TouchableOpacity onPress={() => router.replace(`/policy/${repo}`)} style={[styles.primaryButton, { paddingHorizontal: 16 }]}>
+          <Text style={styles.primaryButtonText}>Back to Policy</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[{ flex: 1, paddingVertical: 16 }, commonStyles.appContainer]}>
+      {/* Include EasyMDE CSS on web for styling */}
+      {isWeb && (
+        <Head>
+          <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" />
+          <title>Policy Editor</title>
+        </Head>
+      )}
+
+      <ScrollView ref={scrollRef} contentContainerStyle={{ paddingHorizontal: isMobile ? 16 : 32, paddingBottom: 100 }}>
+        <View style={{ marginBottom: 16, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text style={{ color: colors.text, fontSize: 22, fontWeight: '700' }}>Policy Editor: {repo}</Text>
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <TouchableOpacity style={[styles.secondaryButton]} onPress={() => router.replace(`/policy/${repo}`)}>
+              <Text style={styles.secondaryButtonText}>Back to View</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.primaryButton]} onPress={handleSave} disabled={saving}>
+              <Text style={styles.primaryButtonText}>{saving ? 'Saving…' : 'Save & Create PR'}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* Mode toggle */}
+        <View style={{ flexDirection: 'row', marginBottom: 16, gap: 8 }}>
+          <TouchableOpacity
+            style={[styles.modeButton, !isPreview && styles.modeButtonActive]}
+            onPress={() => setIsPreview(false)}
+          >
+            <Text style={[styles.modeButtonText, !isPreview && styles.modeButtonTextActive]}>Edit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.modeButton, isPreview && styles.modeButtonActive]}
+            onPress={() => setIsPreview(true)}
+          >
+            <Text style={[styles.modeButtonText, isPreview && styles.modeButtonTextActive]}>Preview</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Commit controls */}
+        <View style={{ flexDirection: isMobile ? 'column' : 'row', gap: 8, marginBottom: 12 }}>
+          <TextInput
+            style={[styles.input, { flex: 2 }]}
+            placeholder="Commit message"
+            placeholderTextColor={colors.textSecondary}
+            value={commitMessage}
+            onChangeText={setCommitMessage}
+          />
+          <TextInput
+            style={[styles.input, { flex: 1 }]}
+            placeholder="Branch name (optional)"
+            placeholderTextColor={colors.textSecondary}
+            value={branchName}
+            onChangeText={setBranchName}
+          />
+        </View>
+
+        {/* Editor/Preview */}
+        {loading ? (
+          <View style={{ paddingVertical: 40, alignItems: 'center' }}>
+            <ActivityIndicator color={colors.accent} />
+            <Text style={{ color: colors.text, marginTop: 8 }}>Loading content…</Text>
+          </View>
+        ) : isPreview ? (
+          <View style={styles.previewContainer}>
+            <ScrollView style={{ flex: 1 }}>
+              <Markdown
+                style={{
+                  body: { color: colors.text, fontSize: 16 },
+                  heading1: { color: colors.text, borderBottomColor: colors.border, borderBottomWidth: 1, paddingBottom: 8 },
+                  heading2: { color: colors.text },
+                  heading3: { color: colors.text },
+                  heading4: { color: colors.text },
+                  heading5: { color: colors.text },
+                  heading6: { color: colors.text },
+                  hr: { backgroundColor: colors.border },
+                  strong: { color: colors.text },
+                  em: { color: colors.text },
+                  s: { color: colors.textSecondary },
+                  blockquote: { backgroundColor: colors.surface, borderLeftColor: colors.accent, borderLeftWidth: 4, paddingLeft: 16 },
+                  bullet_list: {},
+                  ordered_list: {},
+                  list_item: { color: colors.text },
+                  code_inline: { backgroundColor: colors.surface, color: colors.text, fontFamily: 'monospace' },
+                  code_block: { backgroundColor: colors.surface, color: colors.text, fontFamily: 'monospace', padding: 12, borderRadius: 8 },
+                  fence: { backgroundColor: colors.surface, color: colors.text, fontFamily: 'monospace', padding: 12, borderRadius: 8 },
+                  table: { borderColor: colors.border },
+                  thead: {},
+                  tbody: {},
+                  th: { backgroundColor: colors.surface, color: colors.text, fontWeight: 'bold', borderColor: colors.border },
+                  td: { color: colors.text, borderColor: colors.border },
+                  link: { color: colors.accent },
+                  image: {},
+                  text: { color: colors.text },
+                  paragraph: { color: colors.text },
+                }}
+              >
+                {content || '*No content to preview*'}
+              </Markdown>
+            </ScrollView>
+          </View>
+        ) : isWeb && WebMDE ? (
+          <View style={styles.editorWebContainer}>
+            {/* @ts-ignore */}
+            <WebMDE
+              value={content}
+              onChange={(v: string) => setContent(v)}
+              options={{
+                spellChecker: true,
+                // Disable autofocus to avoid auto-scroll to editor on load
+                autofocus: false,
+                status: false,
+                minHeight: '400px',
+                placeholder: 'Edit policy markdown…',
+                toolbar: [
+                  'bold', 'italic', 'heading', '|',
+                  'quote', 'unordered-list', 'ordered-list', '|',
+                  'link', 'table', '|', 'preview', 'side-by-side', 'fullscreen'
+                ],
+              }}
+            />
+          </View>
+        ) : (
+          <TextInput
+            style={styles.editorInput}
+            multiline
+            value={content}
+            onChangeText={setContent}
+            placeholder="Edit policy markdown…"
+            placeholderTextColor={colors.textSecondary}
+          />
+        )}
+
+        {error && (
+          <Text style={{ color: colors.error, marginTop: 12 }}>{error}</Text>
+        )}
+
+        {/* Bottom actions for mobile */}
+        <View style={{ height: 24 }} />
+        <View style={{ flexDirection: 'row', gap: 8 }}>
+          <TouchableOpacity style={[styles.secondaryButton, { flex: 1 }]} onPress={() => router.replace(`/policy/${repo}`)}>
+            <Text style={styles.secondaryButtonText}>Cancel</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={[styles.primaryButton, { flex: 1 }]} onPress={handleSave} disabled={saving}>
+            <Text style={styles.primaryButtonText}>{saving ? 'Saving…' : 'Save & Create PR'}</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const getStyles = (colors: any, isMobile: boolean) => StyleSheet.create({
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    color: colors.text,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  editorWebContainer: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: colors.surface,
+  },
+  editorInput: {
+    minHeight: 400,
+    color: colors.text,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: 12,
+    textAlignVertical: 'top',
+    fontFamily: 'monospace',
+    fontSize: 16,
+  },
+  previewContainer: {
+    minHeight: 400,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: 16,
+  },
+  modeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  modeButtonActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  modeButtonText: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  modeButtonTextActive: {
+    color: '#fff',
+  },
+  primaryButton: {
+    backgroundColor: colors.accent,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  secondaryButton: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/datetimepicker": "8.4.1",
         "axios": "^1.11.0",
         "date-fns": "^4.1.0",
+        "easymde": "^2.20.0",
         "expo": "53.0.20",
         "expo-constants": "^17.1.7",
         "expo-dev-client": "~5.2.4",
@@ -39,6 +40,7 @@
         "react-native-safe-area-context": "^5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-web": "^0.20.0",
+        "react-simplemde-editor": "^5.2.0",
         "react-time-picker": "^8.0.2"
       },
       "devDependencies": {
@@ -2646,6 +2648,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.16",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.16.tgz",
+      "integrity": "sha512-V/yHdamffSS075jit+fDxaOAmdP2liok8NSNJnAZfDJErzOheuygHZEhAJrfmk5TEyM32MhkZjwo/idX791yxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2712,6 +2723,12 @@
       "version": "7.0.15",
       "license": "MIT"
     },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2744,6 +2761,15 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "license": "MIT"
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3693,6 +3719,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "5.65.20",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+      "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
+      "license": "MIT"
+    },
+    "node_modules/codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typo-js": "*"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "license": "MIT",
@@ -4161,6 +4202,19 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "license": "MIT"
+    },
+    "node_modules/easymde": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.20.0.tgz",
+      "integrity": "sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "^5.60.10",
+        "@types/marked": "^4.0.7",
+        "codemirror": "^5.65.15",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^4.1.0"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6278,6 +6332,18 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/marky": {
@@ -8491,6 +8557,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-simplemde-editor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-5.2.0.tgz",
+      "integrity": "sha512-GkTg1MlQHVK2Rks++7sjuQr/GVS/xm6y+HchZ4GPBWrhcgLieh4CjK04GTKbsfYorSRYKa0n37rtNSJmOzEDkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "~5.60.5"
+      },
+      "peerDependencies": {
+        "easymde": ">= 2.0.0 < 3.0.0",
+        "react": ">=16.8.2",
+        "react-dom": ">=16.8.2"
+      }
+    },
     "node_modules/react-time-picker": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-8.0.2.tgz",
@@ -9621,6 +9701,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.1.tgz",
+      "integrity": "sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.40",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-native-community/datetimepicker": "8.4.1",
     "axios": "^1.11.0",
     "date-fns": "^4.1.0",
+    "easymde": "^2.20.0",
     "expo": "53.0.20",
     "expo-constants": "^17.1.7",
     "expo-dev-client": "~5.2.4",
@@ -41,6 +42,7 @@
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "^0.20.0",
+    "react-simplemde-editor": "^5.2.0",
     "react-time-picker": "^8.0.2"
   },
   "devDependencies": {

--- a/frontend/util/seo.ts
+++ b/frontend/util/seo.ts
@@ -21,11 +21,35 @@ export const SEO_DATA: Record<string, SEOData> = {
     type: 'website'
   },
   
+  policy: {
+    title: 'Policies - Progress UK',
+    description: "Explore Progress UK's policies and guiding principles shaping Britain's future.",
+    url: `${BASE_URL}/policy`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
+    type: 'website'
+  },
+
+  'privacy-policy': {
+    title: 'Privacy Policy - Progress UK',
+    description: 'Read how Progress UK collects, uses, and protects your personal information.',
+    url: `${BASE_URL}/privacy-policy`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
+    type: 'website'
+  },
+
+  eula: {
+    title: 'End User License Agreement - Progress UK',
+    description: 'The terms governing your use of the Progress UK app and services.',
+    url: `${BASE_URL}/eula`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
+    type: 'website'
+  },
+
   about: {
     title: 'About Us - Progress UK',
     description: 'Learn about Progress UK\'s mission to revitalize Britain. Formed by engineers, founders, NHS professionals, and more - united by the belief that Britain\'s decline can be stopped.',
     url: `${BASE_URL}/about`,
-    image: `${BASE_URL}/public/assets/progress-uk-about-social.png`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
     type: 'website'
   },
   
@@ -33,7 +57,7 @@ export const SEO_DATA: Record<string, SEOData> = {
     title: 'Our Approach - Progress UK',
     description: '2029 is an historic opportunity for regime change. Discover how Progress UK plans to seize this moment with the most talented team in the country.',
     url: `${BASE_URL}/our-approach`,
-    image: `${BASE_URL}/public/assets/progress-uk-approach-social.png`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
     type: 'website'
   },
   
@@ -41,7 +65,7 @@ export const SEO_DATA: Record<string, SEOData> = {
     title: 'Join Us - Progress UK',
     description: 'Join Progress UK and help build the most serious new party in the country. Be part of the 2029 opportunity to transform British politics.',
     url: `${BASE_URL}/join`,
-    image: `${BASE_URL}/public/assets/progress-uk-join-social.png`,
+    image: `${BASE_URL}/public/assets/favicon.png`,
     type: 'website'
   },
   


### PR DESCRIPTION
This pull request introduces improvements to both backend and frontend policy management, focusing on enhanced user attribution, better handling of GitHub authentication, and improved frontend UX for policy viewing and editing. The changes ensure that user names are included in branch and pull request creation, streamline how private keys are managed for GitHub App authentication, and add a new policy details page with editing capabilities for authorized users.

**Backend improvements:**

* **GitHub App authentication now reads the private key from a file (`policy-access.private-key.pem`) instead of the environment variable, improving security and deployment flexibility. The error message has also been updated to reflect this requirement.**
* **When editing policies, the backend now uses the authenticated user's first and last name to personalize branch names, commit messages, and pull request titles/bodies, improving traceability of changes.** [[1]](diffhunk://#diff-36d207a584a4074b6bef4b3df102cfad6681c4001da11d9c19e387fe8dc74c4fR146-R148) [[2]](diffhunk://#diff-36d207a584a4074b6bef4b3df102cfad6681c4001da11d9c19e387fe8dc74c4fL153-R159) [[3]](diffhunk://#diff-36d207a584a4074b6bef4b3df102cfad6681c4001da11d9c19e387fe8dc74c4fL180-R186) [[4]](diffhunk://#diff-36d207a584a4074b6bef4b3df102cfad6681c4001da11d9c19e387fe8dc74c4fL190-R199)
* **JWT tokens now include `firstName` and `lastName` for both user creation and login, so user details are available on the frontend.** [[1]](diffhunk://#diff-6b4398132c959949a11a2469432f892ef551953ed469951be4868cc5fdfc776bL252-R254) [[2]](diffhunk://#diff-6b4398132c959949a11a2469432f892ef551953ed469951be4868cc5fdfc776bL422-R426)

**Frontend improvements:**

* **A new policy details page (`frontend/app/policy/[repo].tsx`) displays policy content, branches, and pull requests. Writers and admins can access an editor and see related branches/PRs.** ([frontend/app/policy/[repo].tsxR1-R252](diffhunk://#diff-f80e82ea5ec37ef8efbfe8702a59a8517f4261c6a61cf5a250467dcd096557faR1-R252))
* **The layout logic now hides the header and aurora background on the policy editor route, providing a cleaner editing experience.** [[1]](diffhunk://#diff-b69c0bf13160e1b27ab22f8bd5b5fc5e0524e668a9ff49d21e61644bc203c07cL53-R55) [[2]](diffhunk://#diff-b69c0bf13160e1b27ab22f8bd5b5fc5e0524e668a9ff49d21e61644bc203c07cL109-R110)

**Other:**

* **Removed the unused `GITHUB_PRIVATE_KEY` line from the `.env.example` file, reflecting the switch to file-based private key management.**