### PR TITLE
Approve join application

### DIFF
--- a/backend/controllers/pendingUserController.js
+++ b/backend/controllers/pendingUserController.js
@@ -300,7 +300,6 @@ const approveApplication = async (req, res) => {
           firstName: pendingUser.firstName,
           lastName: pendingUser.lastName,
           constituency: pendingUser.constituency,
-          role: pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER',
           roles: [pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER'],
           expiresAt
         }
@@ -461,10 +460,10 @@ const validateAccessCode = async (req, res) => {
         lastName: accessCodeRecord.lastName || pendingUser.lastName,
         constituency: accessCodeRecord.constituency || pendingUser.constituency,
         volunteer: pendingUser.volunteer,
-        role: accessCodeRecord.role || (pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER'),
-        roles: (Array.isArray(accessCodeRecord.roles) && accessCodeRecord.roles.length)
-          ? accessCodeRecord.roles
-          : [accessCodeRecord.role || (pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER')]
+        role: (Array.isArray(accessCodeRecord.roles) && accessCodeRecord.roles.length)
+          ? accessCodeRecord.roles[0]
+          : (pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER'),
+        roles: accessCodeRecord.roles || [pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER']
       }
     });
   } catch (error) {
@@ -684,7 +683,6 @@ const updateApplicationStatus = async (req, res) => {
             firstName: pendingUser.firstName,
             lastName: pendingUser.lastName,
             constituency: pendingUser.constituency,
-            role: pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER',
             roles: [pendingUser.volunteer ? 'VOLUNTEER' : 'MEMBER'],
             expiresAt
           }


### PR DESCRIPTION
This pull request updates how user roles are assigned and handled in the `pendingUserController.js` logic, improving consistency and supporting multiple roles for users. The changes primarily focus on ensuring both `role` and `roles` fields are correctly populated during user approval, validation, and status updates.

Role assignment and handling improvements:

* In `approveApplication` and `updateApplicationStatus`, replaced the single `role` field with an array `roles`, ensuring users are assigned roles as an array for future extensibility. [[1]](diffhunk://#diff-cb3edf86c77fab078716ebf6c4e6e8d2bbafde1e3bec54d3d95744a1a84935a9L303) [[2]](diffhunk://#diff-cb3edf86c77fab078716ebf6c4e6e8d2bbafde1e3bec54d3d95744a1a84935a9L687)
* In `validateAccessCode`, updated logic to set `role` to the first element of `roles` if multiple roles exist, and ensured `roles` is always an array, defaulting to the user's volunteer status if not specified.